### PR TITLE
More robust fasta suffixes parsing logic

### DIFF
--- a/inst/simsearch.sh
+++ b/inst/simsearch.sh
@@ -2,8 +2,7 @@
 
 INSTALLED_PATH=$(Rscript -e "cat(system.file(package = 'pannagram'))")
 
-FASTA_NUCL_EXT=("fa" "fasta" "fas" "fna" "fn" "ffn")
-FASTA_PROT_EXT=("fa" "fasta" "fas" "faa" "mpfa")
+FASTA_SUFFIX=("fa" "fasta" "fas" "fna" "fn" "ffn" "faa")
 
 source "$INSTALLED_PATH/utils/chunk_error_control.sh"
 source "$INSTALLED_PATH/utils/utils_bash.sh"
@@ -29,7 +28,7 @@ if [ ! -z "$path_genome" ]; then
     path_genome=$(add_symbol_if_missing "$path_genome" "/")
     db_files=()
 
-    for ext in "${FASTA_NUCL_EXT[@]}"; do
+    for ext in "${FASTA_SUFFIX[@]}"; do
         for genome_file in "$path_genome"/*.$ext; do
             if [ -e "$genome_file" ]; then
                 db_file=$(basename "$genome_file")

--- a/inst/utils/argparse_simsearch.sh
+++ b/inst/utils/argparse_simsearch.sh
@@ -2,7 +2,7 @@
 #            PARAMETERS
 # ----------------------------------------------------------------------------
 
-# Function to check if a file has a specific extension
+# Function to check if a file has a valid FASTA extension
 has_extension() {
     local filename="$1"
     shift
@@ -15,26 +15,6 @@ has_extension() {
         fi
     done
     return 1
-}
-
-validate_fasta_suffix() {
-    local file="$1"
-    local expected_type="$2"
-
-    if [ ! -f "$file" ]; then
-        pokaz_error "Error: FASTA file not found: $file"
-        return 1
-    fi
-
-    if [[ "$expected_type" == "FASTA with protein sequences" ]] && ! has_extension "$file" "${FASTA_PROT_EXT[@]}"; then
-        pokaz_error "Error: $expected_type was expected for '$file'. Acceptable suffixes are: ${FASTA_PROT_EXT[*]}"
-        return 1
-    elif [[ "$expected_type" == "FASTA with nucleotide sequences" ]] && ! has_extension "$file" "${FASTA_NUCL_EXT[@]}"; then
-        pokaz_error "Error: $expected_type was expected for '$file'. Acceptable suffixes are: ${FASTA_NUCL_EXT[*]}"
-        return 1
-    fi
-
-    return 0
 }
 
 if [ $# -eq 0 ]; then
@@ -129,27 +109,32 @@ fi
 
 # Validate -in_seq
 if [ -n "$file_input" ]; then
-    if [ "$use_aa" -eq 1 ]; then
-        expected_type="FASTA with protein sequences"
-    else
-        expected_type="FASTA with nucleotide sequences"
-    fi
-
-    if ! validate_fasta_suffix "$file_input" "$expected_type"; then
+    if ! has_extension "$file_input" "${FASTA_SUFFIX[@]}"; then
+        pokaz_error "Error: Invalid FASTA file: '$file_input'. Acceptable suffixes are: ${FASTA_SUFFIX[*]}"
         exit 1
     fi
 fi
 
 # Validate -on_seq if set
 if [ -n "$file_seq" ]; then
-    if ! validate_fasta_suffix "$file_seq" "FASTA with nucleotide sequences"; then
+    if [ ! -f "$file_seq" ]; then
+        pokaz_error "Error: File not found: $file_seq"
+        exit 1
+    fi
+    if ! has_extension "$file_seq" "${FASTA_SUFFIX[@]}"; then
+        pokaz_error "Error: Invalid FASTA file: '$file_seq'. Acceptable suffixes are: ${FASTA_SUFFIX[*]}"
         exit 1
     fi
 fi
 
 # Validate -on_genome if set
 if [ -n "$file_genome" ]; then
-    if ! validate_fasta_suffix "$file_genome" "FASTA with nucleotide sequences"; then
+    if [ ! -f "$file_genome" ]; then
+        pokaz_error "Error: File not found: $file_genome"
+        exit 1
+    fi
+    if ! has_extension "$file_genome" "${FASTA_SUFFIX[@]}"; then
+        pokaz_error "Error: Invalid FASTA file: '$file_genome'. Acceptable suffixes are: ${FASTA_SUFFIX[*]}"
         exit 1
     fi
 fi
@@ -161,13 +146,18 @@ if [ -n "$path_genome" ]; then
         exit 1
     fi
 
+    found_fasta=0
     for genome_file in "$path_genome"/*; do
-        if [ -f "$genome_file" ]; then
-            if ! validate_fasta_suffix "$genome_file" "FASTA with nucleotide sequences"; then
-                exit 1
-            fi
+        if [ -f "$genome_file" ] && has_extension "$genome_file" "${FASTA_SUFFIX[@]}"; then
+            found_fasta=1
+            break
         fi
     done
+
+    if [ "$found_fasta" -eq 0 ]; then
+        pokaz_error "Error: No FASTA files found in directory: $path_genome"
+        exit 1
+    fi
 fi
 
 # Check if similarity threshold parameter is provided


### PR DESCRIPTION
* No distiction between nucleotide and protein fasta suffixes (`.fna` vs `.faa`)
* `validate_fasta_suffix` entirely removed
* `on_path` now doesn't throw upon non-FASTA files in specified path