### PR TITLE
`.Rbuildignore`

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,1 @@
+^((?!^(DESCRIPTION|NAMESPACE|inst|R|man)(/|$)).)*$


### PR DESCRIPTION
Excluding all non-essential files from building R package